### PR TITLE
update bootstrap version to 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN cd /tmp && \
     ./aws/install && \
     rm -rf aws*
 
-ARG BOOTSTRAP_VERSION=1.17.13
+ARG BOOTSTRAP_VERSION=1.20.6
 RUN mkdir -p /root/bootstrap && \
     cd /root/bootstrap && \
     curl -sL https://dl.google.com/go/go${BOOTSTRAP_VERSION}.linux-amd64.tar.gz | tar zxf -


### PR DESCRIPTION
[builds](https://github.com/compiler-explorer/compiler-workflows/actions/workflows/build-daily-go.yml) failing for two weeks with:
```
  Building Go cmd/dist using /root/bootstrap/go. (go1.17.13 linux/amd64)
  found packages main (build.go) and building_Go_requires_Go_1_20_6_or_later (notgo120.go) in /root/master/go/src/cmd/dist
  Error: Process completed with exit code 1.
```