### PR TITLE
Update bootstrap go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN cd /tmp && \
     ./aws/install && \
     rm -rf aws*
 
-ARG BOOTSTRAP_VERSION=1.20.6
+ARG BOOTSTRAP_VERSION=1.22.6
 RUN mkdir -p /root/bootstrap && \
     cd /root/bootstrap && \
     curl -sL https://dl.google.com/go/go${BOOTSTRAP_VERSION}.linux-amd64.tar.gz | tar zxf -


### PR DESCRIPTION
Needed due to error during build:

```
 Building Go cmd/dist using /root/bootstrap/go. (go1.20.6 linux/amd64)
  found packages main (build.go) and building_Go_requires_Go_1_22_6_or_later (notgo122.go) in /root/master/go/src/cmd/dist
  Error: Process completed with exit code 1.
```
